### PR TITLE
upgrade hansott/psr-cookies from 2.0 to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^7.4",
         "ext-session": "^7.4",
-        "hansott/psr7-cookies": "^2.0.2",
+        "hansott/psr7-cookies": "^3.0.2",
         "psr/http-message": "^1.0.1",
         "react/cache": "^1.1.1",
         "react/http": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06d8747d9a524f4b834d98ba13eb14a6",
+    "content-hash": "3aec1789dc85eeadbb2d4c257f6ba374",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -55,27 +55,26 @@
         },
         {
             "name": "hansott/psr7-cookies",
-            "version": "2.0.2",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hansott/psr7-cookies.git",
-                "reference": "2c43fc7720b475289a150ec3be8b81d283da768b"
+                "reference": "0d7f31d4f1d989421fe5227d8ef7f32ecd8f57ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hansott/psr7-cookies/zipball/2c43fc7720b475289a150ec3be8b81d283da768b",
-                "reference": "2c43fc7720b475289a150ec3be8b81d283da768b",
+                "url": "https://api.github.com/repos/hansott/psr7-cookies/zipball/0d7f31d4f1d989421fe5227d8ef7f32ecd8f57ef",
+                "reference": "0d7f31d4f1d989421fe5227d8ef7f32ecd8f57ef",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.0",
+                "php": "^7.0 || ^8.0",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
                 "guzzlehttp/psr7": "^1.3",
-                "phpunit/phpunit": "~4.0||~5.0",
-                "scrutinizer/ocular": "~1.1",
-                "squizlabs/php_codesniffer": "~2.3"
+                "phpunit/phpunit": "^5.7 || ^6.0 || ^7.5",
+                "scrutinizer/ocular": "~1.1"
             },
             "type": "library",
             "extra": {
@@ -95,12 +94,11 @@
             "authors": [
                 {
                     "name": "Hans Ott",
-                    "email": "hansott@hotmail.be",
-                    "homepage": "https://hansott.github.io",
+                    "email": "hans@iott.consulting",
                     "role": "Developer"
                 }
             ],
-            "description": "PSR-7 Cookies",
+            "description": "🍪 bakes cookies for PSR-7 messages",
             "homepage": "https://github.com/hansott/psr7-cookies",
             "keywords": [
                 "cookies",
@@ -112,9 +110,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hansott/psr7-cookies/issues",
-                "source": "https://github.com/hansott/psr7-cookies/tree/master"
+                "source": "https://github.com/hansott/psr7-cookies/tree/3.0.2"
             },
-            "time": "2019-03-23T15:17:46+00:00"
+            "time": "2020-07-19T10:15:58+00:00"
         },
         {
             "name": "psr/http-message",

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace WyriHaximus\React\Http\Middleware;
 
-use HansOtt\PSR7Cookies\RequestCookies;
 use HansOtt\PSR7Cookies\SetCookie;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -39,7 +38,7 @@ final class SessionMiddleware
     private SessionIdInterface $sessionId;
 
     /**
-     * @param array<int, mixed> $cookieParams
+     * @param array<int, mixed>       $cookieParams
      */
     public function __construct(
         string $cookieName,
@@ -79,14 +78,14 @@ final class SessionMiddleware
     private function fetchSessionFromRequest(ServerRequestInterface $request): PromiseInterface
     {
         $id      = '';
-        $cookies = RequestCookies::createFromRequest($request);
+        $cookies = $request->getCookieParams();
 
         try {
-            if (! $cookies->has($this->cookieName)) {
+            if (! array_key_exists($this->cookieName, $cookies)) {
                 return resolve(new Session($id, [], $this->sessionId));
             }
 
-            $id = $cookies->get($this->cookieName)->getValue();
+            $id = $cookies[$this->cookieName];
 
             return $this->fetchSessionDataFromCache($id)->then(
                 fn (array $sessionData): Session => new Session($id, $sessionData, $this->sessionId)

--- a/tests/SessionMiddlewareTest.php
+++ b/tests/SessionMiddlewareTest.php
@@ -48,7 +48,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         10,
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                     ],
                 ];
             },
@@ -62,7 +62,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         '/example/',
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                     ],
                 ];
@@ -78,7 +78,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         'www.example.com',
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                         'domain=www.example.com',
                     ],
@@ -96,7 +96,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         true,
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                         'domain=www.example.com',
                         'secure',
@@ -115,7 +115,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         false,
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                         'domain=www.example.com',
                     ],
@@ -134,7 +134,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         true,
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                         'domain=www.example.com',
                         'secure',
@@ -155,7 +155,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         false,
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                         'domain=www.example.com',
                     ],
@@ -174,7 +174,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                         true,
                     ],
                     [
-                        'expires=' . gmdate('D, d-M-Y H:i:s T', time() + 10),
+                        'expires=' . gmdate('D, d M Y H:i:s T', time() + 10),
                         'path=/example/',
                         'domain=www.example.com',
                         'httponly',
@@ -206,7 +206,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                     $t,
                     sprintf(
                         '; expires=%s',
-                        gmdate('D, d-M-Y H:i:s T', time() + $t)
+                        gmdate('D, d M Y H:i:s T', time() + $t)
                     ),
                 ];
             },
@@ -220,7 +220,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                     $t,
                     sprintf(
                         '; expires=%s',
-                        gmdate('D, d-M-Y H:i:s T', time() + $t)
+                        gmdate('D, d M Y H:i:s T', time() + $t)
                     ),
                 ];
             },
@@ -234,7 +234,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
                     $t,
                     sprintf(
                         '; expires=%s',
-                        gmdate('D, d-M-Y H:i:s T', time() + $t)
+                        gmdate('D, d M Y H:i:s T', time() + $t)
                     ),
                 ];
             },
@@ -407,7 +407,7 @@ final class SessionMiddlewareTest extends AsyncTestCase
 
         self::assertCount(0, $this->cache->getData());
         self::assertFalse($session->isActive());
-        self::assertSame($cookieName . '=deleted; expires=Thu, 01-Jan-1970 00:00:01 GMT', $response->getHeaderLine('Set-Cookie'));
+        self::assertSame($cookieName . '=deleted; expires=Thu, 01 Jan 1970 00:00:01 GMT', $response->getHeaderLine('Set-Cookie'));
     }
 
     public function testUpdateCacheDeletesOldIds(): void


### PR DESCRIPTION
https://github.com/hansott/psr7-cookies/releases/tag/3.0.0 made the upgrade pretty easy.

I was unable to test it on php 8 because `composer upgrade` said
```
  - roave/backward-compatibility-check 5.0.0 requires php ^7.4.7 -> your php version (8) does not satisfy that requirement.
```

The roave library is from `wyrihaximus/test-utilities  3.6.2  requires  roave/backward-compatibility-check (^5.0.0) `, and does not yet appear to support php ^8.